### PR TITLE
Give Home access to Asunder

### DIFF
--- a/ca.littlesvr.asunder.yaml
+++ b/ca.littlesvr.asunder.yaml
@@ -20,9 +20,9 @@ finish-args:
 # Required to load music metadata
 - --share=network
 
-# Required for input-output
-- --filesystem=xdg-download
-- --filesystem=xdg-music
+# Required for input-output. On request of Upstream,
+# full home permissions have been given.
+- --filesystem=home
 - --env=TMPDIR=/var/tmp
 
 cleanup:


### PR DESCRIPTION
Request from Upstream. This will make the application work better while still using GTK 2.