### PR TITLE
Remove lame dependency. Is part of freedesktop.platform

### DIFF
--- a/ca.littlesvr.asunder.yaml
+++ b/ca.littlesvr.asunder.yaml
@@ -46,9 +46,7 @@ modules:
     - type: archive
       url: https://github.com/mstorsjo/fdk-aac/archive/v2.0.1.tar.gz
       sha256: a4142815d8d52d0e798212a5adea54ecf42bcd4eec8092b37a8cb615ace91dc6
-#  post-install:
-#    - ln -s /app/lib/libfdk-aac.so /app/bin/fdkaac
-
+      
 - name: fdkaac
   buildsystem: simple
   build-commands:
@@ -61,6 +59,7 @@ modules:
       url: https://github.com/nu774/fdkaac/archive/1.0.0.tar.gz
       sha256: 1cb1a245d3b230d9c772e69aea091e6195073cbd8cc7d63e684af7d69b495365
 
+# Is part of freedesktop. Can be removed when 20.08 provides the latest version of Flac
 - name: flac
   buildsystem: autotools
   config-opts:
@@ -71,20 +70,6 @@ modules:
       sha256: 213e82bd716c9de6db2f98bcadbc4c24c7e2efe8c75939a1a84e28539c4e1748
   cleanup:
     - /share/aclocal
-
-# Lame 3.99.5 is in the shared modules, but this is newer
-- name: lame
-  buildsystem: autotools
-  config-opts:
-    - --enable-nasm
-    - --with-fileio=sndfile
-    - --disable-static
-    # else we require ncurses ¯\_(ツ)_/¯
-    - --disable-frontend
-  sources:
-    - type: archive
-      url: http://deb.debian.org/debian/pool/main/l/lame/lame_3.100.orig.tar.gz
-      sha256: ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e
 
 # The config.guess patches are required because the latest version of the
 # vorbis-tools is from 2008, long before aarch64 existed.


### PR DESCRIPTION
Related to #11 

In the future, Flac can also be removed when an updated version of freedesktop.platform comes around.