### PR TITLE
Update runtime to 20.08

### DIFF
--- a/ca.littlesvr.asunder.yaml
+++ b/ca.littlesvr.asunder.yaml
@@ -66,7 +66,7 @@ modules:
   buildsystem: autotools
   sources:
     - type: archive
-      url: http://deb.debian.org/debian/pool/main/v/vorbis-tools/vorbis-tools_1.4.0.orig.tar.gz
+      url: https://downloads.xiph.org/releases/vorbis/vorbis-tools-1.4.0.tar.gz
       sha256: a389395baa43f8e5a796c99daf62397e435a7e73531c9f44d9084055a05d22bc
     - type: file
       path: ./config-patches/config.guess

--- a/ca.littlesvr.asunder.yaml
+++ b/ca.littlesvr.asunder.yaml
@@ -59,18 +59,6 @@ modules:
       url: https://github.com/nu774/fdkaac/archive/1.0.0.tar.gz
       sha256: 1cb1a245d3b230d9c772e69aea091e6195073cbd8cc7d63e684af7d69b495365
 
-# Is part of freedesktop. Can be removed when 20.08 provides the latest version of Flac
-- name: flac
-  buildsystem: autotools
-  config-opts:
-    - -disable-xmms-plugin
-  sources:
-    - type: archive
-      url: http://deb.debian.org/debian/pool/main/f/flac/flac_1.3.3.orig.tar.xz
-      sha256: 213e82bd716c9de6db2f98bcadbc4c24c7e2efe8c75939a1a84e28539c4e1748
-  cleanup:
-    - /share/aclocal
-
 # The config.guess patches are required because the latest version of the
 # vorbis-tools is from 2008, long before aarch64 existed.
 # https://github.com/xiph/vorbis-tools/issues/22

--- a/ca.littlesvr.asunder.yaml
+++ b/ca.littlesvr.asunder.yaml
@@ -133,17 +133,19 @@ modules:
         - autoreconf -i
 
 # Instruction taken from org.freac.freac.json
+# Plan for shared module: 
+# https://github.com/flathub/shared-modules/pull/121
 - name: mac
   buildsystem: simple
   build-commands:
     - make -f Source/Projects/NonWindows/Makefile prefix=/app all install
   sources:
     - type: archive
-      url: https://monkeysaudio.com/files/MAC_SDK_538d.zip
-      sha256: dab699501f5cc044f8937a369f91aec0a04e8b9f05576e299db4c1b9f8883c0a
+      url: https://freac.org/patches/MAC_SDK_544.zip
+      sha256: d5d2c2de4f64c61bc98c59a8691e47a6e2bb1beb3a3ae50d98bb0fdfdb91e480
       strip-components: 0
     - type: patch
-      path: ./mac-patches/mac-sdk-5.33-gcc.patch
+      path: ./mac-patches/mac-sdk-5.44-gcc.patch
 
 # The config.guess patches are required because the latest version of the
 # libcddb is from 2008, long before aarch64 existed.

--- a/ca.littlesvr.asunder.yaml
+++ b/ca.littlesvr.asunder.yaml
@@ -104,15 +104,6 @@ modules:
       url: https://archive.mozilla.org/pub/opus/opus-tools-0.2.tar.gz
       sha256: b4e56cb00d3e509acfba9a9b627ffd8273b876b4e2408642259f6da28fa0ff86
 
-# Wavpack is the most straigthforward of them all
-- name: wavpack
-  buildsystem: autotools
-  sources:
-    - type: archive
-      url: http://www.wavpack.com/wavpack-5.3.0.tar.bz2
-      sha256: b6f00b3a2185a1d2df6cf8d893ec60fd645d2eb90db7428a617fd27c9e8a6a01
-  cleanup:
-    - /bin/wvtag
 
 # Instruction taken from org.freac.freac.json
 - name: musepack

--- a/ca.littlesvr.asunder.yaml
+++ b/ca.littlesvr.asunder.yaml
@@ -1,7 +1,7 @@
 app-id: ca.littlesvr.asunder
 runtime: org.freedesktop.Platform
 sdk: org.freedesktop.Sdk
-runtime-version: "19.08"
+runtime-version: "20.08"
 command: asunder
 
 rename-desktop-file: asunder.desktop
@@ -128,6 +128,8 @@ modules:
 
 # Instruction taken from org.freac.freac.json
 - name: musepack
+  buildsystem: autotools
+  disabled: true
   sources:
     - type: archive
       url: https://files.musepack.net/source/musepack_src_r475.tar.gz

--- a/ca.littlesvr.asunder.yaml
+++ b/ca.littlesvr.asunder.yaml
@@ -108,7 +108,8 @@ modules:
 # Instruction taken from org.freac.freac.json
 - name: musepack
   buildsystem: autotools
-  disabled: true
+  config-opts:
+    - LDFLAGS=-Wl,--allow-multiple-definition
   sources:
     - type: archive
       url: https://files.musepack.net/source/musepack_src_r475.tar.gz

--- a/mac-patches/mac-sdk-5.44-gcc.patch
+++ b/mac-patches/mac-sdk-5.44-gcc.patch
@@ -1,6 +1,6 @@
-diff -Naur mac-sdk-5.33/Makefile mac-sdk-5.33-gcc/Makefile
---- mac-sdk-5.33/Makefile	1970-01-01 00:00:00 +0000
-+++ mac-sdk-5.33-gcc/Makefile	2019-11-21 21:28:57 +0000
+diff -Naur mac-sdk-5.44/Makefile mac-sdk-5.44-gcc/Makefile
+--- mac-sdk-5.44/Makefile	1970-01-01 00:00:00 +0000
++++ mac-sdk-5.44-gcc/Makefile	2019-11-21 21:28:57 +0000
 @@ -0,0 +1,8 @@
 +all:
 +	$(MAKE) -f Source/Projects/NonWindows/Makefile
@@ -10,10 +10,10 @@ diff -Naur mac-sdk-5.33/Makefile mac-sdk-5.33-gcc/Makefile
 +
 +clean:
 +	$(MAKE) -f Source/Projects/NonWindows/Makefile clean
-diff -Naur mac-sdk-5.33/Shared/All.h mac-sdk-5.33-gcc/Shared/All.h
---- mac-sdk-5.33/Shared/All.h	2020-04-15 17:34:35 +0000
-+++ mac-sdk-5.33-gcc/Shared/All.h	2020-04-15 18:14:47 +0000
-@@ -108,46 +108,17 @@
+diff -Naur mac-sdk-5.44/Shared/All.h mac-sdk-5.44-gcc/Shared/All.h
+--- mac-sdk-5.44/Shared/All.h	2020-04-24 13:08:43 +0000
++++ mac-sdk-5.44-gcc/Shared/All.h	2020-05-04 13:10:52 +0000
+@@ -117,46 +117,17 @@
  #define ENABLE_COMPRESSION_MODE_HIGH
  #define ENABLE_COMPRESSION_MODE_EXTRA_HIGH
  
@@ -62,7 +62,7 @@ diff -Naur mac-sdk-5.33/Shared/All.h mac-sdk-5.33-gcc/Shared/All.h
  
      typedef uint64_t                                    uint64;
      typedef uint32_t                                    uint32;
-@@ -201,10 +172,14 @@
+@@ -210,10 +181,14 @@
      #define TICK_COUNT_FREQ                             1000000
      #undef    ASSERT
      #define ASSERT(e)
@@ -78,9 +78,9 @@ diff -Naur mac-sdk-5.33/Shared/All.h mac-sdk-5.33-gcc/Shared/All.h
      #define strcpy_s(A, B, C) strcpy(A, C)
      #define _tcscat_s(A, B, C) _tcscat(A, C)
  #endif
-diff -Naur mac-sdk-5.33/Shared/NoWindows.h mac-sdk-5.33-gcc/Shared/NoWindows.h
---- mac-sdk-5.33/Shared/NoWindows.h	2019-12-03 22:21:06 +0000
-+++ mac-sdk-5.33-gcc/Shared/NoWindows.h	2019-12-15 10:16:26 +0000
+diff -Naur mac-sdk-5.44/Shared/NoWindows.h mac-sdk-5.44-gcc/Shared/NoWindows.h
+--- mac-sdk-5.44/Shared/NoWindows.h	2020-06-18 15:34:55 +0000
++++ mac-sdk-5.44-gcc/Shared/NoWindows.h	2020-06-19 17:01:26 +0000
 @@ -48,7 +48,7 @@
  #define _totlower towlower
  #define _totupper towupper
@@ -89,11 +89,11 @@ diff -Naur mac-sdk-5.33/Shared/NoWindows.h mac-sdk-5.33-gcc/Shared/NoWindows.h
 +#define _tcsicmp wcscmp
  #define _tcscpy wcscpy
  #define _tcslen wcslen
- 
-diff -Naur mac-sdk-5.33/Source/Console/Console.cpp mac-sdk-5.33-gcc/Source/Console/Console.cpp
---- mac-sdk-5.33/Source/Console/Console.cpp	2020-01-16 23:41:58 +0000
-+++ mac-sdk-5.33-gcc/Source/Console/Console.cpp	2020-01-27 22:39:38 +0000
-@@ -21,7 +21,12 @@
+ #define _tcsncpy wcsncpy
+diff -Naur mac-sdk-5.44/Source/Console/Console.cpp mac-sdk-5.44-gcc/Source/Console/Console.cpp
+--- mac-sdk-5.44/Source/Console/Console.cpp	2020-06-18 15:33:19 +0000
++++ mac-sdk-5.44-gcc/Source/Console/Console.cpp	2020-06-19 17:35:08 +0000
+@@ -23,17 +23,27 @@
  #define UNDEFINED_MODE        -1
  
  // use 8 bit character functions on non-Windows platforms
@@ -105,11 +105,50 @@ diff -Naur mac-sdk-5.33/Source/Console/Console.cpp mac-sdk-5.33-gcc/Source/Conso
 +    #endif
 +#else
      #define _tmain(argc, argv) main(argc, argv)
++    #define _tcscpy(dst, src) strcpy(dst, src)
      #define _tcscpy_s(dst, num, src) strcpy(dst, src)
++    #define _tcsncpy(dst, src, count) strncpy(dst, src, count)
      #define _tcsncpy_s(dst, num, src, count) strncpy(dst, src, count)
-diff -Naur mac-sdk-5.33/Source/MACLib/APEInfo.cpp mac-sdk-5.33-gcc/Source/MACLib/APEInfo.cpp
---- mac-sdk-5.33/Source/MACLib/APEInfo.cpp	2020-04-13 22:37:20 +0000
-+++ mac-sdk-5.33-gcc/Source/MACLib/APEInfo.cpp	2020-04-15 15:23:05 +0000
+     #define _tcsnicmp(str1, str2, count) strncasecmp(str1, str2, count)
++    #define _tcslen(str) strlen(str)
++    #define _tcsstr(str1, str2) strstr(str1, str2)
+     #define _ftprintf fprintf
+     #define _ttoi(str) atoi(str)
+     #ifdef _T
+       #undef _T
+     #endif
+     #define TCHAR char
++    #define LPCTSTR const char *
+     #define _T(x) x
+ #endif
+ 
+@@ -347,7 +357,22 @@
+                     TCHAR cRight[256];
+                     _tcscpy(cRight, &pEqual[1]);
+ 
+-                    pTag->SetFieldString(cLeft, cRight);
++                    CSmartPtr<wchar_t> spLeft; CSmartPtr<wchar_t> spRight;
++
++                    #ifdef PLATFORM_WINDOWS
++                        #ifdef _UNICODE
++                            spLeft.Assign(cLeft, TRUE, FALSE);
++                            spRight.Assign(cRight, TRUE, FALSE);
++                        #else
++                            spLeft.Assign(CAPECharacterHelper::GetUTF16FromANSI(cLeft), TRUE);
++                            spRight.Assign(CAPECharacterHelper::GetUTF16FromANSI(cRight), TRUE);
++                        #endif
++                    #else
++                        spLeft.Assign(CAPECharacterHelper::GetUTF16FromUTF8((str_utf8*) cLeft), TRUE);
++                        spRight.Assign(CAPECharacterHelper::GetUTF16FromUTF8((str_utf8*) cRight), TRUE);
++                    #endif
++
++                    pTag->SetFieldString(spLeft, spRight);
+                 }
+ 
+                 delete [] pParameter;
+diff -Naur mac-sdk-5.44/Source/MACLib/APEInfo.cpp mac-sdk-5.44-gcc/Source/MACLib/APEInfo.cpp
+--- mac-sdk-5.44/Source/MACLib/APEInfo.cpp	2020-04-13 22:37:20 +0000
++++ mac-sdk-5.44-gcc/Source/MACLib/APEInfo.cpp	2020-05-04 13:15:05 +0000
 @@ -15,7 +15,7 @@
  /*****************************************************************************************
  Construction
@@ -128,9 +167,9 @@ diff -Naur mac-sdk-5.33/Source/MACLib/APEInfo.cpp mac-sdk-5.33-gcc/Source/MACLib
      {
          CloseFile();
          *pErrorCode = ERROR_INVALID_INPUT_FILE;
-diff -Naur mac-sdk-5.33/Source/MACLib/APEInfo.h mac-sdk-5.33-gcc/Source/MACLib/APEInfo.h
---- mac-sdk-5.33/Source/MACLib/APEInfo.h	2020-04-13 22:04:55 +0000
-+++ mac-sdk-5.33-gcc/Source/MACLib/APEInfo.h	2020-04-15 15:23:35 +0000
+diff -Naur mac-sdk-5.44/Source/MACLib/APEInfo.h mac-sdk-5.44-gcc/Source/MACLib/APEInfo.h
+--- mac-sdk-5.44/Source/MACLib/APEInfo.h	2020-06-09 18:21:40 +0000
++++ mac-sdk-5.44-gcc/Source/MACLib/APEInfo.h	2020-06-13 16:06:24 +0000
 @@ -75,7 +75,7 @@
  public:
      
@@ -140,10 +179,10 @@ diff -Naur mac-sdk-5.33/Source/MACLib/APEInfo.h mac-sdk-5.33-gcc/Source/MACLib/A
      CAPEInfo(int * pErrorCode, APE::CIO * pIO, CAPETag * pTag = NULL);
      virtual ~CAPEInfo();
  
-diff -Naur mac-sdk-5.33/Source/MACLib/MACLib.cpp mac-sdk-5.33-gcc/Source/MACLib/MACLib.cpp
---- mac-sdk-5.33/Source/MACLib/MACLib.cpp	2020-04-13 23:23:36 +0000
-+++ mac-sdk-5.33-gcc/Source/MACLib/MACLib.cpp	2020-04-15 15:25:54 +0000
-@@ -84,7 +84,7 @@
+diff -Naur mac-sdk-5.44/Source/MACLib/MACLib.cpp mac-sdk-5.44-gcc/Source/MACLib/MACLib.cpp
+--- mac-sdk-5.44/Source/MACLib/MACLib.cpp	2020-04-24 13:17:55 +0000
++++ mac-sdk-5.44-gcc/Source/MACLib/MACLib.cpp	2020-05-04 13:13:59 +0000
+@@ -94,7 +94,7 @@
      else if (StringIsEqual(pExtension, L".mac", false) || StringIsEqual(pExtension, L".ape", false))
      {
          // plain .ape file
@@ -152,10 +191,22 @@ diff -Naur mac-sdk-5.33/Source/MACLib/MACLib.cpp mac-sdk-5.33-gcc/Source/MACLib/
      }
  
      // fail if we couldn't get the file information
-diff -Naur mac-sdk-5.33/Source/Shared/All.h mac-sdk-5.33-gcc/Source/Shared/All.h
---- mac-sdk-5.33/Source/Shared/All.h	2020-04-15 17:34:35 +0000
-+++ mac-sdk-5.33-gcc/Source/Shared/All.h	2020-04-15 18:14:47 +0000
-@@ -108,46 +108,17 @@
+diff -Naur mac-sdk-5.44/Source/Projects/NonWindows/Makefile mac-sdk-5.44-gcc/Source/Projects/NonWindows/Makefile
+--- mac-sdk-5.44/Source/Projects/NonWindows/Makefile	2020-04-24 21:09:10 +0000
++++ mac-sdk-5.44-gcc/Source/Projects/NonWindows/Makefile	2020-06-18 19:16:27 +0000
+@@ -85,7 +85,7 @@
+ 	$(CC) $(SHAREDOBJECTS) $(LIBOBJECTS) $(DLLOBJECTS) $(LDOPTS) $(LDFLAGS) $(DLLLDOPTS) -o $@
+ 
+ $(CMDNAME): $(DLLNAME) $(CMDOBJECTS)
+-	$(CC) $(SHAREDOBJECTS) $(CMDOBJECTS) $(DLLNAME) $(LDOPTS) $(LDFLAGS) $(CMDLDOPTS) -o $@
++	$(CC) $(SHAREDOBJECTS) $(LIBOBJECTS) $(CMDOBJECTS) $(LDOPTS) $(LDFLAGS) $(CMDLDOPTS) -o $@
+ 
+ Source/Shared/%.o: Source/Shared/%.cpp
+ 	$(CXX) $(CXXOPTS) $(CXXFLAGS) $< -o $@
+diff -Naur mac-sdk-5.44/Source/Shared/All.h mac-sdk-5.44-gcc/Source/Shared/All.h
+--- mac-sdk-5.44/Source/Shared/All.h	2020-04-24 13:08:43 +0000
++++ mac-sdk-5.44-gcc/Source/Shared/All.h	2020-05-04 13:10:52 +0000
+@@ -117,46 +117,17 @@
  #define ENABLE_COMPRESSION_MODE_HIGH
  #define ENABLE_COMPRESSION_MODE_EXTRA_HIGH
  
@@ -204,7 +255,7 @@ diff -Naur mac-sdk-5.33/Source/Shared/All.h mac-sdk-5.33-gcc/Source/Shared/All.h
  
      typedef uint64_t                                    uint64;
      typedef uint32_t                                    uint32;
-@@ -201,10 +172,14 @@
+@@ -210,10 +181,14 @@
      #define TICK_COUNT_FREQ                             1000000
      #undef    ASSERT
      #define ASSERT(e)
@@ -220,9 +271,9 @@ diff -Naur mac-sdk-5.33/Source/Shared/All.h mac-sdk-5.33-gcc/Source/Shared/All.h
      #define strcpy_s(A, B, C) strcpy(A, C)
      #define _tcscat_s(A, B, C) _tcscat(A, C)
  #endif
-diff -Naur mac-sdk-5.33/Source/Shared/NoWindows.h mac-sdk-5.33-gcc/Source/Shared/NoWindows.h
---- mac-sdk-5.33/Source/Shared/NoWindows.h	2019-12-03 22:21:06 +0000
-+++ mac-sdk-5.33-gcc/Source/Shared/NoWindows.h	2019-12-15 10:16:26 +0000
+diff -Naur mac-sdk-5.44/Source/Shared/NoWindows.h mac-sdk-5.44-gcc/Source/Shared/NoWindows.h
+--- mac-sdk-5.44/Source/Shared/NoWindows.h	2020-06-18 15:34:55 +0000
++++ mac-sdk-5.44-gcc/Source/Shared/NoWindows.h	2020-06-19 17:01:26 +0000
 @@ -48,7 +48,7 @@
  #define _totlower towlower
  #define _totupper towupper
@@ -231,9 +282,9 @@ diff -Naur mac-sdk-5.33/Source/Shared/NoWindows.h mac-sdk-5.33-gcc/Source/Shared
 +#define _tcsicmp wcscmp
  #define _tcscpy wcscpy
  #define _tcslen wcslen
- 
-diff -Naur mac-sdk-5.33/configure mac-sdk-5.33-gcc/configure
---- mac-sdk-5.33/configure	1970-01-01 00:00:00 +0000
-+++ mac-sdk-5.33-gcc/configure	2019-11-21 21:28:57 +0000
+ #define _tcsncpy wcsncpy
+diff -Naur mac-sdk-5.44/configure mac-sdk-5.44-gcc/configure
+--- mac-sdk-5.44/configure	1970-01-01 00:00:00 +0000
++++ mac-sdk-5.44-gcc/configure	2019-11-21 21:28:57 +0000
 @@ -0,0 +1 @@
 +#!/bin/sh


### PR DESCRIPTION
There is one minor issue left, Musepack is currently not supported because of `--allow-multiple-definition` being required. Still, this is a good improvement over the current live version since it actually cuts down on custom libs. Flac and Wavpack are now both updated in the runtime.