### PR TITLE
Update Asunder to GTK 3 

### DIFF
--- a/ca.littlesvr.asunder.desktop
+++ b/ca.littlesvr.asunder.desktop
@@ -1,0 +1,24 @@
+[Desktop Entry]
+Name=Asunder CD Ripper
+Name[de]=Asunder
+Name[fr]=Asunder
+Name[hu]=Asunder
+Name[sv]=Asunder
+Name[ru]=Asunder
+GenericName=Audio CD Ripper
+GenericName[de]=Ein graphischer CD-Ripper und Encoder
+GenericName[fr]=Extracteur de CD
+GenericName[hu]=Audió CD Ripper és Tömörítő
+GenericName[ru]=Копирование звуковых CD
+Comment=An application to save tracks from an Audio CD as WAV, MP3, OGG, FLAC, and/or Wavpack.
+Comment[de]=Oberfläche zur Erstellung von Audio-Dateien
+Comment[hu]=Egy alkalmazás ami az Audió CD-n lévő sávokat lementi, MP3, OGG, FLAC és/vagy Wavpack formátumba.
+Comment[ru]=Программа для сохранения звуковых дорожек CD в файлы форматов WAV, MP3, OGG, FLAC и/или Wavpack.
+Comment[sv]=Ett program för att spara spår från en ljudskiva som WAV, MP3, OGG och/eller FLAC.
+Exec=asunder
+Terminal=false
+StartupNotify=true
+Type=Application
+Categories=AudioVideo;Audio;
+Icon=ca.littlesvr.asunder
+MimeType=x-content/audio-cdda;

--- a/ca.littlesvr.asunder.yaml
+++ b/ca.littlesvr.asunder.yaml
@@ -4,9 +4,6 @@ sdk: org.freedesktop.Sdk
 runtime-version: "20.08"
 command: asunder
 
-rename-desktop-file: asunder.desktop
-rename-icon: asunder
-
 finish-args:
 - --socket=wayland
 - --socket=x11
@@ -33,8 +30,6 @@ cleanup:
 - /lib/*.la
 
 modules:
-
-- shared-modules/gtk2/gtk2.json
 
 # AAC support comes in two parts, a codec and a commandline utility
 - name: fdk-aac
@@ -157,23 +152,19 @@ modules:
         - cp -p /usr/share/automake-*/config.guess ./configure.guess
 
 - name: asunder
-  buildsystem: autotools
+  buildsystem: meson
   config-opts:
     - --prefix=/app
   sources:
-    - type: archive
-      url: http://littlesvr.ca/asunder/releases/asunder-2.9.7.tar.bz2
-      sha256: c1c97cd34c04b8595e95df8a9a7dbc64a1e61f494b7a0cd2873802ad111874f4
-  post-install:
-    - install -Dm 644 ./asunder.desktop -t /app/share/applications/
-    - install -Dm 644 ./pixmaps/asunder.png -t /app/share/icons/hicolor/128x128/apps/
-    - install -Dm 644 ./pixmaps/asunder.svg -t /app/share/icons/hicolor/scalable/apps/
+    - type: git
+      url: https://gitlab.gnome.org/Salamandar/asunder
+      branch: master
 
 - name: metadata
   buildsystem: simple
   build-commands:
-    - install -Dm 644 ca.littlesvr.asunder.metainfo.xml -t /app/share/metainfo/
+    - install -Dm 644 ./ca.littlesvr.asunder.desktop -t /app/share/applications/
   sources:
     - type: file
-      path: ca.littlesvr.asunder.metainfo.xml
+      path: ca.littlesvr.asunder.desktop
 


### PR DESCRIPTION
This is a demonstration branch, showing Asunder ported to GTK 3. Using this branch, it's possible to make a reasonable assumption about how much work would be involved in porting Asunder.