### PR TITLE
Patch the .desktop file to add StartupWMClass

### DIFF
--- a/add-wm-class.patch
+++ b/add-wm-class.patch
@@ -1,0 +1,22 @@
+From 6babcd0199a4432400fe3da48a07b8208fc9909b Mon Sep 17 00:00:00 2001
+From: Stan Janssen <stan@finetuned.nl>
+Date: Wed, 15 Dec 2021 09:08:50 +0100
+Subject: [PATCH] Add StartupWMClass to .desktop file
+
+---
+ asunder.desktop | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/asunder.desktop b/asunder.desktop
+index bfd7a63..ec61367 100644
+--- a/asunder.desktop
++++ b/asunder.desktop
+@@ -22,4 +22,4 @@ Type=Application
+ Categories=AudioVideo;Audio;
+ Icon=asunder
+ MimeType=x-content/audio-cdda;
+-
++StartupWMClass=Asunder
+-- 
+2.25.1
+

--- a/ca.littlesvr.asunder.yaml
+++ b/ca.littlesvr.asunder.yaml
@@ -195,6 +195,8 @@ modules:
         type: anitya
         project-id: 124
         url-template: http://littlesvr.ca/asunder/releases/asunder-$version.tar.bz2
+    - type: patch
+      path: add-wm-class.patch
   post-install:
     - install -Dm 644 ./asunder.desktop -t /app/share/applications/
     - install -Dm 644 ./pixmaps/asunder.png -t /app/share/icons/hicolor/128x128/apps/


### PR DESCRIPTION
This prevents the Dock icon from being duplicated on elementaryOS

Please see https://github.com/elementary/dock/issues/64 for background information.